### PR TITLE
Add translations for behaviour tree node docs

### DIFF
--- a/behavior-trees/nodes/CheckKeyState.md
+++ b/behavior-trees/nodes/CheckKeyState.md
@@ -1,0 +1,34 @@
+---
+title: CheckKeyState
+description:
+published: true
+date: 2025-08-17T08:36:34.854Z
+tags:
+editor: markdown
+dateCreated: 2025-08-17T08:36:34.854Z
+---
+
+**CheckKeyState** is a node that checks whether a specific keyboard key is currently pressed. If the chosen key is held down at the moment of the check, the node returns `Success`; otherwise it returns `Failure`.
+
+![CheckKeyState parameters](https://s3.eyeauras.net/media/2025/08/EyeAuras_dfgmUF8kNg.png)
+
+## How to use
+
+1. Specify the key in the **Hotkey** parameter.
+2. Insert the node where you need it in the scenario.
+3. On each run it performs the check:
+   - If the key is pressed, CheckKeyState returns `Success`.
+   - If it isn't pressed, it returns `Failure`.
+> If no key is selected, the result will always be `Failure`.
+
+## Example
+```
+Sequence
+├── CheckKeyState (Hotkey = F1)
+├── DoSomethingWhileF1Pressed
+```
+
+In this example the actions in `DoSomethingWhileF1Pressed` run only while the user holds F1.
+
+## What is it good for?
+- Create branches in the tree that work only while a certain key is held, adjusting behavior on the fly.

--- a/behavior-trees/nodes/Debounce.md
+++ b/behavior-trees/nodes/Debounce.md
@@ -1,0 +1,32 @@
+---
+title: Debounce
+description:
+published: true
+date: 2025-08-17T08:20:07.721Z
+tags:
+editor: markdown
+dateCreated: 2025-08-17T08:20:07.721Z
+---
+
+The Debounce node lets you configure the system to react only to real changes and ignore noise. Sometimes behavior logic rapidly switches back and forth—working, then not working. These flickers can interfere with your system.
+
+The Debounce node helps fix that!
+
+If its child node suddenly changes state (for example, success → failure → success), Debounce doesn't rush to pass the change along. It waits a bit to make sure the new state is stable and not just a flash.
+
+![Debounce](https://s3.eyeauras.net/media/2025/08/EyeAuras_u25y8UknQG.png)
+
+## Blocking Behavior
+### Wait until Stabilizes:
+The node returns `Running` until the state stabilizes, meaning the entire tree is **blocked** during this period.
+
+### Return immediately:
+The node immediately returns the current state—`Failure` if it hasn't stabilized yet, otherwise `Success`.
+
+## Activation Timeout, ms:
+How many milliseconds the child node must keep returning `Success` for that success to be considered real.
+
+## Deactivation Timeout, ms:
+How many milliseconds the child node must keep returning `Failure` for that failure to be considered real.
+
+Example: If a door quickly opens and closes but you care only when it stays open for a while, `Debounce` lets you ignore random door flaps until it's stably open for X milliseconds.

--- a/behavior-trees/nodes/Interrupter.md
+++ b/behavior-trees/nodes/Interrupter.md
@@ -1,0 +1,42 @@
+---
+title: Interrupter
+description:
+published: true
+date: 2025-08-17T08:33:00.641Z
+tags:
+editor: markdown
+dateCreated: 2025-08-17T08:33:00.641Z
+---
+
+**Interrupter** is a special node for behaviour trees and macros in EyeAuras that helps interrupt long‑running actions when certain conditions occur.
+
+## How Interrupter works
+
+Interrupter always has two children:
+
+1. **Condition** – something to check (for example, character health below 20%).
+2. **Action** – a task to perform (for example, wait a few seconds or use an ability).
+
+### Main principle
+
+- While **Action** is running, Interrupter constantly watches **Condition**.
+- If **Condition** becomes `true` at any moment while **Action** is executing:
+  - Interrupter immediately stops the **Action**.
+  - Returns `Failure`.
+- If **Condition** does not become `true` before **Action** completes:
+  - Interrupter returns the result of that action (`Success`, `Failure`, or `Running`).
+
+## Simple example
+```
+Interrupter
+├── Condition: Mana drops below 10%
+└── Action: Cast Meditate
+```
+
+- While the character meditates, Interrupter monitors mana.
+- If mana suddenly falls below 10%, Meditate is interrupted and Interrupter returns `Failure`.
+- If mana stays above 10% and the action finishes, Interrupter returns whatever result the action produced.
+
+## When is it useful?
+- Cancel long actions if something happens.
+- React quickly to changing conditions during an action (e.g., interrupt recovery when an enemy appears or stats drop).

--- a/behavior-trees/nodes/IsActive.md
+++ b/behavior-trees/nodes/IsActive.md
@@ -1,0 +1,46 @@
+---
+title: IsActive
+description:
+published: true
+date: 2025-08-17T08:30:21.182Z
+tags:
+editor: markdown
+dateCreated: 2025-08-17T08:30:21.182Z
+---
+
+**CheckIsActive** is a special node used in macros and behaviour trees in EyeAuras. It checks whether the current tree or macro is active and, if necessary, stops execution early.
+
+![Params](https://s3.eyeauras.net/media/2025/08/EyeAuras_QxRuxRhJEV.png)
+
+## Why do you need it?
+
+At the beginning of each tick the tree will not start if it is disabled (for example, if you removed the active checkmark). Sometimes you need to check the status not only at the start but at any point during the macro or tree execution. In such cases CheckIsActive lets you:
+
+- Check whether the current tree or macro is disabled.
+- If the tree is disabled (or enabled, depending on the parameters), finish execution immediately with the desired status (`Failure` or `Success`).
+
+An example situation: you want the tree to finish early if it was deactivated during work—then insert CheckIsActive at the necessary point.
+
+## Invert
+
+CheckIsActive has an **Invert** option: when enabled the node checks for INACTIVITY instead:
+
+- If **Invert = off** (default): the node returns `Success` when the tree or macro is active and `Failure` when it is not.
+- If **Invert = on**: it is the opposite—`Success` when the tree is **inactive**, and `Failure` when it is active.
+
+This is convenient if you need the opposite behaviour, reacting to deactivation rather than activation of the tree or macro.
+
+## How CheckIsActive works
+- Insert the node in the required place in the tree or macro.
+- On tick it checks the current active status.
+- You can combine it with other nodes to end the tree early (for example, in a Sequence or Selector).
+
+## Simple example
+```
+Sequence
+ ├── CheckIsActive (Invert = false)   ← Checks that the tree is active
+ ├── DoSomething                      ← Executes if the tree is active
+```
+In this example, if the tree is disabled while running, the sequence finishes with `Failure` and subsequent actions are skipped.
+
+**CheckIsActive** helps make scenarios more controllable when it's important to quickly react to changes in the tree or macro's active state right from inside the execution chain.

--- a/behavior-trees/nodes/KeyPress.md
+++ b/behavior-trees/nodes/KeyPress.md
@@ -1,0 +1,34 @@
+---
+title: KeyPress
+description:
+published: true
+date: 2025-08-17T08:56:58.706Z
+tags:
+editor: markdown
+dateCreated: 2025-08-17T08:56:58.706Z
+---
+
+**KeyPress** is a node that simulates pressing selected keys on the keyboard. Thanks to this node, macros and trees can "press" keys for the user to execute commands, send shortcuts, or emulate other actions in programs and games.
+
+![KeyPress](https://s3.eyeauras.net/media/2025/08/EyeAuras_vIJngJ7rpT.png)
+
+# Main parameters
+- **Keys** – choose one or several keys to press. You can specify single buttons (e.g., A) or combinations (e.g., Ctrl+C).
+- **Key Press Delay** – delay between presses in milliseconds, making the input more human‑like.
+- **Input Type**
+  - **Press and release ⬇⬆** – a normal tap: the key is pressed and immediately released.
+  - **Press and hold ⬇** – the key is pressed and held.
+  - **Release ⬆** – only releases a key that was previously held.
+
+## Example
+```
+KeyPress
+
+Keys: Ctrl + V
+Key Press Delay: 30 ms
+Input Type: Press and release
+```
+In this example the macro presses Ctrl and V together to paste text from the clipboard.
+
+## Long key combos
+`KeyPress` supports only short single presses. For a long sequence use several KeyPress nodes one after another.

--- a/behavior-trees/nodes/MouseMoveAbs.md
+++ b/behavior-trees/nodes/MouseMoveAbs.md
@@ -1,0 +1,46 @@
+---
+title: MouseMove Abs
+description:
+published: true
+date: 2025-08-17T08:50:59.377Z
+tags:
+editor: markdown
+dateCreated: 2025-08-17T08:50:59.377Z
+---
+
+**MouseMove Abs** moves the mouse cursor to a specified point on the screen. In EyeAuras it's often used to automate clicks, interact with the interface or move the mouse to a desired element.
+
+![MouseMove Abs](https://s3.eyeauras.net/media/2025/08/EyeAuras_DOrxeVBXrY.png)
+
+# Main parameters
+**Mouse Position** – coordinates where the cursor should move. You can set fixed X and Y values.
+
+## Move to something section
+This section allows moving the mouse not only to absolute coordinates but also to a search result (icon, text, last found object), an area (Width/Height), or to results of another aura (for example, `ImageSearch`).
+- **Move to Variable:** use pre‑saved or calculated coordinates (for example, a search result on the screen).
+- **Move to Linked Aura:** move the cursor to a specially linked aura.
+
+You can also use the [Bindings](/features/bindings) mechanism—click the black square to the right of the coordinates to open the editor.
+
+![MouseMove Abs - Move to someting section](https://s3.eyeauras.net/media/2025/08/EyeAuras_ttF92DbAou.png)
+
+## Randomize section
+Adds random offset to X and Y so mouse movements look more natural and not always identical. Specify the scatter range for both axes and the cursor will land slightly differently around the point each run.
+
+![MouseMove Abs - Randomize section](https://s3.eyeauras.net/media/2025/08/EyeAuras_fTb1fjQ6Sj.png)
+
+## Add click anchor section
+Lets you choose an "anchor" within a rectangular area—where exactly relative to the found object the cursor should move. For example:
+- Center
+- Top-left
+- Bottom-right
+This is convenient when the area is large but you need to hit a specific spot inside it (center, corner, edge, etc.).
+
+![MouseMove Abs - Click Anchor section](https://s3.eyeauras.net/media/2025/08/EyeAuras_7ewg0RoYQh.png)
+
+## Add offset to mouse position section
+
+Adds an additional offset to the final coordinates:
+- **Offset X, Y:** shift the cursor relative to the already calculated position—useful for more precise or sequential mouse moves.
+
+![MouseMove Abs - Offset section](https://s3.eyeauras.net/media/2025/08/EyeAuras_DMjOlNdH2h.png)

--- a/behavior-trees/nodes/MouseMoveRel.md
+++ b/behavior-trees/nodes/MouseMoveRel.md
@@ -1,0 +1,21 @@
+---
+title: MouseMove Rel
+description:
+published: true
+date: 2025-08-17T08:52:43.668Z
+tags:
+editor: markdown
+dateCreated: 2025-08-17T08:52:43.668Z
+---
+
+**MouseMove Rel** moves the mouse cursor relative to its **current position**.
+
+![MouseMove Rel](https://s3.eyeauras.net/media/2025/08/EyeAuras_pkO20KJVhg.png)
+
+# Main parameters
+**Offset** – specify how many pixels to shift the cursor.
+
+## Randomize section
+Adds random offset to X and Y so mouse movements look more natural and not always identical. Specify the scatter range for both axes and each run will land slightly differently around the point.
+
+![MouseMove Rel - Randomize section](https://s3.eyeauras.net/media/2025/08/EyeAuras_fTb1fjQ6Sj.png)

--- a/behavior-trees/nodes/SendText.md
+++ b/behavior-trees/nodes/SendText.md
@@ -1,0 +1,34 @@
+---
+title: SendText
+description:
+published: true
+date: 2025-08-17T08:39:46.611Z
+tags:
+editor: markdown
+dateCreated: 2025-08-17T08:39:46.611Z
+---
+
+**SendText** automatically "types" text as if you were entering it yourself. It simulates key presses and can be used in macros and trees to send any text—messages, commands, chat lines, etc.
+
+![SendText](https://s3.eyeauras.net/media/2025/08/EyeAuras_ea1jBx1plw.png)
+
+## How it works
+- Enter the text in the **Text** field.
+- Set the delay between keystrokes (**Key Press Delay**, in milliseconds).
+- Choose the input method:
+    - **Type characters** – types each character sequentially like a regular keyboard.
+    - **Shift+Insert** – paste via the standard Ctrl+Shift+Insert combination.
+    - **Control+V** – paste from the clipboard (Ctrl+V).
+
+When it's this node's turn, it "writes" the text using the selected method. It can be text for a game, chat, command line, or anything else.
+
+## Main parameters
+- **Text** – the text to type.
+- **Key Press Delay** – delay between characters so the input looks human.
+- **Method** – how to enter the text (typing or pasting).
+
+## Example
+In the example above, the node types "Hello, World!" one character at a time with a 30 millisecond pause between each.
+
+## What is it useful for?
+- Automatically sending messages, commands, logins, passwords, chat text, and other cases where manual input is required.

--- a/behavior-trees/nodes/root.md
+++ b/behavior-trees/nodes/root.md
@@ -2,19 +2,21 @@
 title: Root
 description: Root Node
 published: true
-date: 2024-03-07T14:53:17.542Z
+date: 2025-08-17T08:11:35.009Z
 tags: tree, settings, logic, recalculation
 editor: markdown
 dateCreated: 2024-03-07T14:51:42.386Z
 ---
-## Why?
-This is the root of your tree. This is where everything begins. It cannot be removed, but you can change the settings that affect **how** and **when** the tree recalculation and actions are performed.
+
+This is the root of your tree. This is where everything begins. You cannot remove it, but you can change the settings that affect **how** and **when** the tree recalculation and actions are executed.
+
+![Tree Root](https://s3.eyeauras.net/media/2025/08/EyeAuras_vs6Z34YfZ2.png)
 
 ### Is Loaded
-Indicates whether the tree is loaded for execution or not, allowing you to conveniently enable/disable the entire tree without changing its logic. The logic of use is the same as with auras.
+Indicates whether the tree is loaded for execution, allowing you to conveniently enable or disable the entire tree without changing its logic. The logic of use is the same as with auras.
 
 ### Tick Every
-Here you can specify how often the tree should be recalculated. Usually, values around 50-100ms are more than enough, but the decision is up to you. In the foreseeable future, another recalculation mode will be introduced - "on demand," which will analyze the tree itself and recalculate exactly when any of the checked conditions have changed.
+Here you can specify how often the tree should be recalculated. Usually, values around 50‑100 ms are more than enough, but the decision is up to you. In the foreseeable future another recalculation mode will appear – "on demand," which will analyze the tree itself and recalc exactly when one of the monitored conditions changes.
 
 ### Is Active
-Here you can set a condition under which the tree should function - whether it's a hotkey or window activation. The logic is exactly the same as in all other parts of the program where there are connections - you specify an aura, and the program monitors its state.
+Here you can set a condition under which the tree should function – whether it's a hotkey or window activation. The logic is exactly the same as in other parts of the program where there are links – you specify an aura and the program monitors its state.


### PR DESCRIPTION
## Summary
- Add English translations for missing BehaviourTree nodes like CheckKeyState, KeyPress, Debounce, Interrupter, IsActive, MouseMove Abs/Rel, and SendText
- Refresh root node documentation with image and updated details

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a19b1744bc8325b28a39417d86d497