### PR TITLE
Add English docs for Blazor Windows subsystem

### DIFF
--- a/scripting/blazor-windows/1-intro.md
+++ b/scripting/blazor-windows/1-intro.md
@@ -1,0 +1,63 @@
+---
+title: 1. What is Blazor and how to use it in EyeAuras
+description:
+published: true
+date: 2025-08-17T09:21:21.000Z
+tags:
+editor: markdown
+dateCreated: 2025-05-11T13:31:15.490Z
+---
+
+[Blazor](https://dotnet.microsoft.com/en-us/apps/aspnet/web-apps/blazor) is a powerful tool that helps build convenient and beautiful interfaces in C#. It was originally intended for web development, but we will use it to build UI for our scripts—settings panels, overlays, pop‑ups. All of this can be done through the API available to you.
+
+# Examples from this series
+All examples can be downloaded [here](https://tinyurl.com/msfhaupc). I recommend downloading the whole pack rather than trying to import it into the current version.
+
+# Creating our first overlay
+It's very easy:
+- Create a new aura
+![New aura](https://s3.eyeauras.net/media/2025/05/NVIDIA_Overlay_KBChU81nd6.png)
+- Add `C# Overlay v3`
+![New Overlay](https://s3.eyeauras.net/media/2025/05/NVIDIA_Overlay_xVFX70YeoA.png)
+- Done
+
+At this point you already have a fully working interactive UI.
+![v3](https://s3.eyeauras.net/media/2025/05/NVIDIA_Overlay_UVQrNGj5te.png)
+
+If you click the `Click Me` button, the counter in the program will start updating!
+![clickme](https://s3.eyeauras.net/media/2025/05/ltZnDlxcvJ.gif)
+
+## Why Blazor?
+[Blazor](https://dotnet.microsoft.com/en-us/apps/aspnet/web-apps/blazor) is great for building interfaces because it combines the flexibility and performance of C# with the incredible capabilities of HTML/CSS and JavaScript. Over the last two decades no stack has received as much investment from the largest companies in the world. As a result we now have a tool that lets us render virtually anything you can imagine. Check out https://codepen.io/ for inspiring examples of what this “magnificent trio” can do.
+
+Now that we've looked at the strengths of HTML/CSS/JS, let's understand the role C#/Blazor plays in all this. In short, Blazor lets us generate HTML and bridge the world of web programming with C#. Our application is split into two parts: [Razor](https://learn.microsoft.com/en-us/aspnet/core/blazor/components/?view=aspnetcore-8.0) and the C# backend. Razor is responsible for rendering data, and C# for preparing it.
+
+EyeAuras—and therefore your scripts—lives at the intersection of these two technologies. Let's dive into the essentials you'll work with.
+
+## [HTML](https://www.w3schools.com/html/)
+It's the markup language on which the entire Internet is built. It controls where elements like text, buttons, tables, etc. appear. You use HTML to define the page layout that you later style with...
+
+## [CSS](https://www.w3schools.com/html/html_css.asp)
+**C**ascading **S**tyle **S**heets control how your buttons, text and everything else look. They change colors, transparency, animations and many other details.
+
+## [Razor](https://learn.microsoft.com/en-us/aspnet/core/blazor/components/?view=aspnetcore-8.0)
+Razor is a markup language from Microsoft that lets you mix HTML, CSS and C# in one file.
+
+Let's create our first component and break down its parts. It will contain text and a button that increases a counter when clicked.
+
+```html
+<h1>Counter</h1>
+
+<p>Current count: @currentCount</p>
+
+<button class="btn btn-primary" @onclick="IncrementCount">Click me</button>
+
+@code {
+    private int currentCount = 0;
+
+    private void IncrementCount() => currentCount++;
+}
+```
+![Counter](https://s3.eyeauras.net/media/2024/11/msedge_Wvy12LEOv1bGyAOA.gif)
+
+In this small piece of code HTML and C# live together and complement each other. C# defines what happens when we click the button, while HTML/CSS define how everything looks.

--- a/scripting/blazor-windows/2-webview.md
+++ b/scripting/blazor-windows/2-webview.md
@@ -1,0 +1,55 @@
+---
+title: 2. BlazorWindows and WebView2
+description:
+published: true
+date: 2025-08-17T09:21:21.000Z
+tags:
+editor: markdown
+dateCreated: 2025-05-11T00:47:25.172Z
+---
+
+# What are Blazor Windows and how do they work?
+In the [introductory part of the series](/scripting/blazor-windows/getting-started) I talked about Blazor, HTML and CSS. To show all this beauty on screen we need a tool that turns our scripts and code into buttons, forms and more. This is where [WebView2](https://developer.microsoft.com/en-us/microsoft-edge/webview2)—an embeddable browser from Microsoft—comes into play.
+
+![WebView2](https://s3.eyeauras.net/media/2025/05/WebView2.drawio%20(1).png)
+You can think of `WebView2` as the part of the application responsible for rendering our components.
+
+`BlazorWindows` is the framework that ties everything together—WebView, HTML, C# and CSS—allowing you to create interactive windows. This technology powers overlays and many parts of EyeAuras.
+
+# What's the difference between windows and overlays?
+Overlays are a variety of windows: it's the same window but with different display options. For example, an overlay is usually drawn on top of other windows.
+
+EyeAuras has several overlay types:
+![Overlays](https://s3.eyeauras.net/media/2025/05/mIYLrG2yj2.png)
+
+# C# Overlay
+This is one of the main ways to quickly create an interface in EyeAuras.
+The idea is simple:
+- we have a configured overlay window with a position, name and visibility condition. More on the contents below.
+- we have a script written in EyeAuras that describes the interface using Razor/HTML/CSS
+- EyeAuras compiles this script and we get a **library** that lets us build the UI rendered in the overlay with **WebView2**
+
+## Overlay settings
+Every overlay has:
+- position and size, and a flag whether the user can move it (`IsLocked`)
+![Overlay position](https://s3.eyeauras.net/media/2025/05/NVIDIA_Overlay_O2I6OKwmjq.png)
+- visual style settings—transparency, border thickness and color, etc.
+![Overlay visual style](https://s3.eyeauras.net/media/2025/05/NVIDIA_Overlay_VfFC6J8Kgd.png)
+- window settings
+![Overlay window style](https://s3.eyeauras.net/media/2025/05/NVIDIA_Overlay_ohz05OLVxV.png)
+The most important toggle here is the window type—Overlay or Window.
+- Window – almost a normal window except there is no close button. It has an icon, title, can be dragged by the title bar, etc.
+- Overlay – a borderless window without drag area or system buttons.
+![Window](https://s3.eyeauras.net/media/2025/05/Njy7t9XEg2.png) ![Overlay](https://s3.eyeauras.net/media/2025/05/R432QeysKh.png)
+
+## C# Overlay v3
+The current overlay version using scripting engine V3. You have access to everything available in scripts—custom Razor controls, NuGet integration, EyeAuras services, etc. Every C# overlay is a small application.
+
+![v3](https://s3.eyeauras.net/media/2025/05/NVIDIA_Overlay_TqJxUFKYNe.png)
+
+## C# Overlay v2 (deprecated)
+Mentioned only briefly since it is no longer recommended. It will be removed in one of the upcoming versions and exists only for backward compatibility, offering no advantages over modern V3.
+
+![v2](https://s3.eyeauras.net/media/2025/05/NVIDIA_Overlay_DKdQydbTcq.png)
+Visually it looks like this.
+![Window](https://s3.eyeauras.net/media/2025/05/NVIDIA_Overlay_AvrTCKw3p6.png) ![Overlay](https://s3.eyeauras.net/media/2025/05/n02buCY4RI.png)

--- a/scripting/blazor-windows/3-hello-world.md
+++ b/scripting/blazor-windows/3-hello-world.md
@@ -1,0 +1,106 @@
+---
+title: 3. Building Blocks
+description:
+published: true
+date: 2025-08-17T09:21:21.000Z
+tags:
+editor: markdown
+dateCreated: 2025-05-11T01:13:28.765Z
+---
+
+# Building Blocks
+When you add a new overlay, several files are created automatically. Each is important to the program.
+![Header](https://s3.eyeauras.net/media/2025/05/NVIDIA_Overlay_uPjkmxmv2r.png)
+
+## Script.csx
+This file is the entry point. Every time the program **creates** a new overlay (not when showing/hiding it) this script runs.
+It can contain nothing beyond the sample code, but you can use it to initialize data, read information, etc. You can also do this in the window/component code, but sometimes it's convenient to have a common entry point.
+```csharp
+Log.Debug("This script is entry point for Overlay");
+```
+
+---
+
+## UserOverlay.cs
+```csharp
+public partial class UserOverlay : BlazorReactiveComponent {
+    private int count = 0;
+
+    private void IncrementCount()
+    {
+        count++;
+    }
+}
+```
+This is the **code-behind** file. Most Razor components consist of two parts—`*.razor` and `*.cs`. The Razor part usually contains Razor/HTML/CSS markup, while the `*.cs` file holds methods, fields and properties accessible from the markup.
+> Note: you *can* write C# directly inside `*.razor` and skip the `*.cs` file, but due to technical limitations **EyeAuras** currently shows IntelliSense only in `*.cs` files, so having both files is recommended.
+{.is-info}
+
+Let's break down the code:
+```csharp
+public partial class UserOverlay : BlazorReactiveComponent
+```
+Class declaration. To let EyeAuras find it, the class must be `public`. Because it has a second part (`*.razor`), it must be `partial`, meaning the class is split across multiple files. Finally, `: BlazorReactiveComponent` sets the base class—more on that later.
+
+```csharp
+private int count = 0;
+```
+We declare a field storing how many times the button was clicked.
+> Note: This field value persists for the lifetime of the overlay. If the aura unloads or the overlay is destroyed, the value is reset.
+
+```csharp
+private void IncrementCount()
+{
+    count++;
+}
+```
+This method simply increments the counter, allowing us to track clicks.
+
+---
+
+## UserOverlay.razor
+```html
+@inherits BlazorReactiveComponent
+
+<h3 class="text-center">Interactive Counter</h3>
+
+<div class="text-center mt-4">
+    <button @onclick="IncrementCount" class="btn btn-primary btn-lg">
+        Click Me
+    </button>
+</div>
+
+<p class="text-center mt-3" style="font-size: 1.5rem;">
+    You clicked <strong>@count</strong> times!
+</p>
+```
+The second part of our component describing how it should render. Let's look at what's inside:
+```html
+@inherits BlazorReactiveComponent
+```
+This tells Blazor to use `BlazorReactiveComponent` (provided by **EyeAuras**) as the base class. It's optional but strongly recommended for access to extra functionality.
+
+```html
+<h3 class="text-center">Interactive Counter</h3>
+```
+Just a centered heading.
+
+```html
+<div class="text-center mt-4">
+    <button @onclick="IncrementCount" class="btn btn-primary btn-lg">
+        Click Me
+    </button>
+</div>
+```
+Here the interesting part is `@onclick="IncrementCount"` which hooks up the click handler. Each click increases `count` by 1.
+
+```html
+<p class="text-center mt-3" style="font-size: 1.5rem;">
+    You clicked <strong>@count</strong> times!
+</p>
+```
+The final piece: display the current value of `count`, the same variable we increment when the button is pressed.
+
+---
+
+We end up with a simple form containing a button and an updating value. In about 20 lines we created a functional and somewhat nice program. Play with colors, add more values and use this overlay as a test bed. More to come!

--- a/scripting/blazor-windows/4-toggle-hotkeyisactive.md
+++ b/scripting/blazor-windows/4-toggle-hotkeyisactive.md
@@ -1,0 +1,125 @@
+---
+title: 4. Creating a toggle
+description:
+published: true
+date: 2025-08-17T09:21:21.000Z
+tags:
+editor: markdown
+dateCreated: 2025-05-11T14:24:53.840Z
+---
+
+# Controlling an aura through the UI
+Let's solve a common task—we want a button somewhere on screen that enables or disables certain functionality.
+
+## Solution using HotkeyIsActive Trigger
+The standard approach:
+- create an aura
+- add a HotkeyIsActive trigger
+- bind a hotkey
+
+That's it: pressing the hotkey toggles the aura state.
+
+## Solution using C# Overlay
+Create another overlay. We'll draw the button there.
+
+## UserOverlay.cs
+```csharp
+public partial class UserOverlay : BlazorReactiveComponent {
+
+    [Inject]
+    public IAuraTreeScriptingApi AuraTree { get; init; }
+
+    public IHotkeyIsActiveTrigger Trigger
+    {
+        get => AuraTree.GetTriggerByPath<IHotkeyIsActiveTrigger>("./TargetAura");
+    }
+
+    public bool TriggerIsActive
+    {
+        get => Trigger.TriggerValue ?? false;
+        set => Trigger.TriggerValue = value;
+    }
+}
+```
+
+## UserOverlay.razor
+```csharp
+@using PoeShared.Blazor.Controls
+@inherits BlazorReactiveComponent
+
+<h3 class="text-center shadow-1">Toggle Trigger</h3>
+
+<div class="text-center mt-4">
+    <ToggleButton
+              @bind-IsChecked="@TriggerIsActive"
+              Class="btn btn-secondary">
+       Trigger is Active
+    </ToggleButton>
+</div>
+
+<p class="text-center mt-3 alert alert-info" style="font-size: 1.5rem;">
+    @if (TriggerIsActive){
+        <span class="shadow-1">Trigger is currently active</span>
+    } else {
+        <span class="text-warning shadow-1">Trigger is currently not active</span>
+    }
+</p>
+```
+
+![Demo](https://s3.eyeauras.net/media/2025/05/NVIDIA_Overlay_HeGx0CejHB.gif)
+
+---
+
+# Breakdown
+Let's go through it in detail.
+
+## UserOverlay.cs
+```csharp
+ [Inject]
+ public IAuraTreeScriptingApi AuraTree { get; init; }
+```
+EyeAuras heavily uses Dependency Injection. Read more about it [here](/scripting/dependency-injection). In short, it lets us access various parts of the program. Here we ask for access to the aura tree. EyeAuras ensures it's available when the script runs. Since we'll change the state of an aura, we need the aura tree.
+
+```csharp
+public IDefaultTrigger Trigger
+{
+   get => AuraTree.GetTriggerByPath<IHotkeyIsActiveTrigger>("./TargetAura");
+}
+```
+This property looks up an aura named `TargetAura` located in the same folder (`./`) and extracts the trigger of type `IHotkeyIsActiveTrigger`. Path rules are the same as file systems—`./` current folder, `..` parent, etc. Both forward and backslashes are supported. If the aura or trigger isn't found, EyeAuras throws an exception.
+
+```csharp
+  public bool TriggerIsActive
+    {
+        get => Trigger.TriggerValue ?? false;
+        set => Trigger.TriggerValue = value;
+    }
+```
+Here we read and set the trigger state.
+- `get` finds the trigger and reads its current value
+- `set` writes a new value
+> Not all triggers have a writable `TriggerValue`, but **all** triggers have `IsActive` to **read** their state. Useful for triggers like ImageSearch/MLSearch to check whether they found anything.
+
+## UserOverlay.razor
+```html
+@using PoeShared.Blazor.Controls
+```
+`ToggleButton` is a component that renders a button with two states (ON/OFF). It's located in the `PoeShared.Blazor.Controls` namespace, so we add `@using PoeShared.Blazor.Controls` to access it.
+
+```html
+<ToggleButton
+              @bind-IsChecked="@TriggerIsActive"
+              Class="btn btn-secondary">
+   Trigger is Active
+</ToggleButton>
+```
+We tell Blazor to render a `ToggleButton`. The key part is `@bind-IsChecked="@TriggerIsActive"` which binds the button state to our property. When rendering, it reads `TriggerIsActive`, and on click it writes back.
+
+```html
+@if (TriggerIsActive){
+   <span class="shadow-1">Trigger is currently active</span>
+} else {
+   <span class="text-warning shadow-1">Trigger is currently not active</span>
+}
+```
+This block shows different text depending on whether the trigger is active. Note that clicking the button updates the text as well.

--- a/scripting/blazor-windows/getting-started.md
+++ b/scripting/blazor-windows/getting-started.md
@@ -1,0 +1,55 @@
+---
+title: Where to start?
+description:
+published: true
+date: 2025-08-17T09:21:21.000Z
+tags:
+editor: markdown
+dateCreated: 2024-11-04T00:26:45.232Z
+---
+
+# Blazor in the context of EyeAuras
+As of November 2024 there are two main ways to use Blazor in EA.
+
+## C# Overlay
+Until recently (Oct 2024) this was the only option. It's simple: create an aura, add a C# Overlay and… that's it. EA takes care of drawing a window on the screen with your code inside. Otherwise it's a regular overlay: you can specify display conditions via triggers, adjust color, background, etc.
+
+Here are a couple of overlay examples:
+![D](https://i.imgur.com/iaKm2Br.png) ![TL](http://files.eyesquad.net/screenshots/31-10-2024/1YWZKXCaFhEh7SNnSx8YMWjAf.png)
+
+### Example
+Let's make a tiny overlay with a button and counter.
+- Create an aura
+- Add C# Overlay
+![Add C# Overlay](https://s3.eyeauras.net/media/2024/11/msedge_zVrveCuFgBbtBB68.png)
+- That's it—the overlay with a clickable button is rendered
+![C# Overlay Example](https://s3.eyeauras.net/media/2024/11/Code_MJvkplH0Iiqmm9SV.png)
+
+> IMPORTANT! The text editor used in this overlay will soon be replaced. Because of that I won't dig into its structure and instead recommend taking a look at option #2—scripts.
+{.is-info}
+
+## C# Script Action
+Now the main course. You can create not just one or two overlays controlled by triggers, but an entire window system driven by scripts. They appear wherever and whenever you want, look however you like. EA relieves you from much of the headache typical of WPF or WinForms, especially around multithreading.
+
+### Example
+Let's see how scripts can work with windows.
+- Create an aura
+- Add **OnEnter** **C# Script** action
+![OnEnter C#](https://s3.eyeauras.net/media/2024/11/EyeAuras_xCVTs8bdg1Y7ZU8T.png)
+- Create a new Razor Component, keep the default name **UserComponent**
+![New Razor Component](https://s3.eyeauras.net/media/2024/11/EyeAuras_I6MYDieptaZe5a8u.png)
+- In **Script.csx** add:
+```csharp
+var window = GetService<IDialogWindowUnstableScriptingApi>() // get DialogWindow API
+    .CreateWindow<UserComponent>() //create new window with UserComponent inside
+    .AddTo(ExecutionAnchors); //destroy when script is stopped
+
+window.WindowStartupLocation = System.Windows.WindowStartupLocation.CenterScreen;
+window.ShowDialog();
+```
+- Press **Run**—here's your first dialog window using the Blazor Windows API! Note that the script keeps running while the window is open, but stopping the script closes the window.
+![Blazor window](https://s3.eyeauras.net/media/2024/11/EyeAuras_fmFnsjgMCW8P6Z4b.png)
+
+### What is IDialogWindowUnstableScriptingApi?
+This is the main interface intended for interacting with dialog windows. There are alternatives, but currently it's the highest-level and safest option—it takes care of unloading windows when an aura unloads, cleaning up resources, etc. It's called **Unstable** not because it's bad but because, being new, it may have breaking changes. Eventually it will become **Stable**.
+

--- a/scripting/blazor-windows/js-loadscript.md
+++ b/scripting/blazor-windows/js-loadscript.md
@@ -1,0 +1,74 @@
+---
+title: 11. Connecting JavaScript
+description:
+published: true
+date: 2025-08-17T09:21:21.000Z
+tags:
+editor: markdown
+dateCreated: 2025-05-12T00:32:40.408Z
+---
+
+# JavaScript and why we need it in 2025
+JS turned static pages into interactive portals long ago. Today so many libraries and frameworks are built on top of JS that it's harder to find places where it's *not* used.
+
+Sooner or later you'll want to use a JS library to enhance user experience. For example, we'll take an absolutely useless but pretty snippet from https://codepen.io/—a creative playground for many talented people. Highly recommended.
+
+So, how do we load JavaScript in Blazor?
+
+## LoadScript
+Just like with [CSS](/scripting/blazor-windows/toggles-styling-cssfile), we can use `IJsPoeBlazorUtils` to load a script whenever we need.
+```csharp
+/// <summary>
+/// Loads a JavaScript file dynamically and returns a promise that completes when the script loads.
+/// </summary>
+Task LoadScript(string scriptPath);
+```
+> IMPORTANT: This method is for loading plain JavaScript. If you want to load [modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) use [another approach](https://learn.microsoft.com/en-us/aspnet/core/blazor/javascript-interoperability/location-of-javascript?view=aspnetcore-9.0).
+
+## What do we want to achieve?
+Since this is just a demo of script loading (and scripts can do anything), we're not aiming for functionality—just an animation.
+
+![Demo](https://s3.eyeauras.net/media/2025/05/9dIx2khkoQ.gif)
+
+## Code
+As examples grow larger, I'll show only the relevant parts worth explaining. You can find the rest by downloading the sample project from [this page](https://wiki.eyeauras.net/ru/scripting/blazor-windows/1-intro).
+
+---
+
+# Code review
+
+## UserOverlay.cs
+```csharp
+[Inject]
+public PoeShared.Blazor.Services.IJsPoeBlazorUtils PoeBlazorUtils { get; init; }
+```
+Just like `IAuraTreeScriptingApi`, we inject another service—this time to load CSS and scripts.
+
+```csharp
+protected override async Task OnAfterFirstRenderAsync()
+{
+    await base.OnAfterFirstRenderAsync();
+    await PoeBlazorUtils.LoadCss("Styles.css");
+    await PoeBlazorUtils.LoadScript("https://raw.githack.com/strangerintheq/rgba/0.0.8/rgba.js");
+    await PoeBlazorUtils.LoadScript("Script.js");
+}
+```
+In one place we load styles and two scripts. One script is on a CDN (`rgba.js`), the other is local (`Script.js`). Mix approaches as needed, though for EyeAuras local storage is generally preferred.
+
+Note that we load everything right after the first render. As a programmer you must decide which scripts to load and when. Here I chose `OnAfterFirstRenderAsync`, but another example might use `OnInitializedAsync` or even a mix. For more about the component lifecycle see [this Microsoft article](https://learn.microsoft.com/en-us/aspnet/core/blazor/components/lifecycle?view=aspnetcore-9.0).
+
+```css
+canvas {
+    position: absolute;
+    width: 100% !important;
+    left: 0;
+    top: 1.5em;
+    height: calc(100% - 1.5em) !important;
+}
+```
+A bit of CSS magic:
+- `position: absolute;` — draw the element in absolute coordinates, independent of its place in the tree. Common for graphics, pop‑ups etc.
+- `width: 100% !important;` — take 100% width; `!important` overrides other styles. Needed here because `rgba.js` sets canvas size itself.
+- `left: 0;` — with absolute positioning we usually specify the location; here we pin it to the left edge.
+- `top: 1.5em;` — add top padding to leave room for the header. There's a more reliable way, but for the demo this is fine.
+- `height: calc(100% - 1.5em) !important;` — combined from everything above: "Important! Element height must be 100% of page height minus 1.5em (header)."

--- a/scripting/blazor-windows/multiple-toggles.md
+++ b/scripting/blazor-windows/multiple-toggles.md
@@ -1,0 +1,96 @@
+---
+title: 6. Multiple toggles
+description:
+published: true
+date: 2025-08-17T09:21:21.000Z
+tags:
+editor: markdown
+dateCreated: 2025-05-11T14:52:06.974Z
+---
+
+# Controlling an aura through the UI
+The code works but isn't perfect. Clicking the button toggles the trigger and aura correctly. But if you activate a trigger **with a hotkey**, the UI doesn't refresh automatically—it needs a signal. We'll use the same simple solution: refresh the interface **once per second**. Not optimal, but fine for our tiny UI.
+
+## UserOverlay.cs
+```csharp
+public partial class UserOverlay : BlazorReactiveComponent {
+
+    [Inject]
+    public IAuraTreeScriptingApi AuraTree { get; init; }
+
+    public bool Trigger1IsActive
+    {
+        get => AuraTree.GetTriggerByPath<IHotkeyIsActiveTrigger>("./TargetAura 1").TriggerValue ?? false;
+        set => AuraTree.GetTriggerByPath<IHotkeyIsActiveTrigger>("./TargetAura 1").TriggerValue = value;
+    }
+
+    public bool Trigger2IsActive
+    {
+        get => AuraTree.GetTriggerByPath<IHotkeyIsActiveTrigger>("./TargetAura 2").TriggerValue ?? false;
+        set => AuraTree.GetTriggerByPath<IHotkeyIsActiveTrigger>("./TargetAura 2").TriggerValue = value;
+    }
+
+    public bool Trigger3IsActive
+    {
+        get => AuraTree.GetTriggerByPath<IHotkeyIsActiveTrigger>("./TargetAura 3").TriggerValue ?? false;
+        set => AuraTree.GetTriggerByPath<IHotkeyIsActiveTrigger>("./TargetAura 3").TriggerValue = value;
+    }
+
+    protected override void OnInitialized()
+    {
+        ChangeTrackers.Add(Observable.Timer(DateTimeOffset.Now, TimeSpan.FromSeconds(1)));
+        base.OnInitialized();
+    }
+}
+```
+
+## UserOverlay.razor
+```html
+@using PoeShared.Blazor.Controls
+@inherits BlazorReactiveComponent
+
+<h3 class="text-center shadow-1">Toggle Multiple Triggers</h3>
+
+<div class="text-center mt-4 mx-2 d-flex gap-1 alert alert-info">
+    <ToggleButton @bind-IsChecked="@Trigger1IsActive">
+        Trigger <b>1</b>
+    </ToggleButton>
+    <ToggleButton @bind-IsChecked="@Trigger2IsActive">
+        Trigger <b>2</b>
+    </ToggleButton>
+    <ToggleButton @bind-IsChecked="@Trigger3IsActive">
+        Trigger <b>3</b>
+    </ToggleButton>
+</div>
+```
+
+![Demo](https://s3.eyeauras.net/media/2025/05/NVIDIA_Overlay_WPu1ZGwKwS.gif)
+
+---
+
+# Breakdown
+## UserOverlay.cs
+```csharp
+    public bool Trigger1IsActive
+    {
+        get => AuraTree.GetTriggerByPath<IHotkeyIsActiveTrigger>("./TargetAura 1").TriggerValue ?? false;
+        set => AuraTree.GetTriggerByPath<IHotkeyIsActiveTrigger>("./TargetAura 1").TriggerValue = value;
+    }
+```
+For convenience we declare properties for each aura. The logic is the same as before, but instead of splitting trigger lookup and value access, we do both at once. `GetTriggerByPath` guarantees the trigger is found (or throws), so this is safe.
+
+## UserOverlay.razor
+```html
+<div class="text-center mt-4 mx-2 d-flex gap-1 alert alert-info">
+    <ToggleButton @bind-IsChecked="@Trigger1IsActive">
+        Trigger <b>1</b>
+    </ToggleButton>
+    ...
+</div>
+```
+Key classes in the parent `<div>`:
+- `d-flex` – lay out elements in a row
+- `gap-1` – small gap between them (`gap-2`, `gap-3`, etc. are also available). These classes come from [Bootstrap](https://getbootstrap.com/)
+- `alert alert-info` – wrap buttons in a colored box for visibility
+
+The buttons themselves changed only by variable name and small style tweaks. See [here](https://getbootstrap.com/docs/5.3/components/buttons/) for more button styles. We'll cover customizing styles next.

--- a/scripting/blazor-windows/reactive-toggle.md
+++ b/scripting/blazor-windows/reactive-toggle.md
@@ -1,0 +1,80 @@
+---
+title: 5. Update mechanism
+description:
+published: true
+date: 2025-08-17T09:21:21.000Z
+tags:
+editor: markdown
+dateCreated: 2025-05-11T14:35:20.794Z
+---
+
+# Controlling an aura through the UI
+The previous code works, but it's imperfect. Clicking the button toggles the trigger and aura as expected. But if you activate the trigger with a **hotkey**, the UI doesn't re-render because it doesn't know it should. We need to signal an update.
+
+For simplicity we solve it head-on: the interface will refresh **once per second**. It's not optimal, but fine for a very simple UI.
+
+## UserOverlay.cs
+```csharp
+public partial class UserOverlay : BlazorReactiveComponent {
+
+    [Inject]
+    public IAuraTreeScriptingApi AuraTree { get; init; }
+
+    public IHotkeyIsActiveTrigger Trigger
+    {
+        get => AuraTree.GetTriggerByPath<IHotkeyIsActiveTrigger>("./TargetAura");
+    }
+
+    public bool TriggerIsActive
+    {
+        get => Trigger.TriggerValue ?? false;
+        set => Trigger.TriggerValue = value;
+    }
+
+    protected override void OnInitialized()
+    {
+        ChangeTrackers.Add(Observable.Timer(DateTimeOffset.Now, TimeSpan.FromSeconds(1)));
+        base.OnInitialized();
+    }
+}
+```
+
+## UserOverlay.razor
+```html
+@using PoeShared.Blazor.Controls
+@inherits BlazorReactiveComponent
+
+<h3 class="text-center shadow-1">Toggle Trigger</h3>
+
+<div class="text-center mt-4">
+    <ToggleButton @bind-IsChecked="@TriggerIsActive"
+    Class="btn btn-secondary">
+                Trigger is Active
+    </ToggleButton>
+</div>
+
+<p class="text-center mt-3 alert alert-info" style="font-size: 1.5rem;">
+    @if (TriggerIsActive){
+        <span class="shadow-1">Trigger is currently active</span>
+    } else {
+        <span class="text-warning shadow-1">Trigger is currently not active</span>
+    }
+</p>
+```
+
+![Demo](https://s3.eyeauras.net/media/2025/05/NVIDIA_Overlay_W7LNmgAsPK.gif)
+
+---
+
+# Breakdown
+## UserOverlay.cs
+```csharp
+ protected override void OnInitialized()
+    {
+        ChangeTrackers.Add(Observable.Timer(DateTimeOffset.Now, TimeSpan.FromSeconds(1)));
+        base.OnInitialized();
+    }
+```
+EyeAuras uses a mechanism to control rendering. One of the simplest ways to use it is to add an event to `ChangeTrackers` in `OnInitialized`. Here it's just a timer—every tick forces the interface to re-render. It doesn't check whether anything changed; it simply says "re-render".
+
+Later we'll look at optimizing via `ReactiveSection` and more precise tracking. For many situations this approach is good enough—`Blazor` is fast and doing a "blank" re-render with a simple UI isn't a crime.

--- a/scripting/blazor-windows/toggle-styling.md
+++ b/scripting/blazor-windows/toggle-styling.md
@@ -1,0 +1,158 @@
+---
+title: 7. Customizing toggles
+description:
+published: true
+date: 2025-08-17T09:21:21.000Z
+tags:
+editor: markdown
+dateCreated: 2025-05-11T15:23:20.489Z
+---
+
+# Adding variety
+One of the main advantages of Blazor/HTML/CSS is incredible flexibility—almost any idea can be implemented and usually it's not too hard, especially compared to many other UI frameworks.
+
+Let's customize our group of toggles and add some color.
+
+![Demo](https://s3.eyeauras.net/media/2025/05/NVIDIA_Overlay_BY6C30fWpS.gif)
+
+## UserOverlay.cs
+```csharp
+public partial class UserOverlay : BlazorReactiveComponent {
+
+    [Inject]
+    public IAuraTreeScriptingApi AuraTree { get; init; }
+
+    public bool Trigger1IsActive
+    {
+        get => AuraTree.GetTriggerByPath<IHotkeyIsActiveTrigger>("./TargetAura 1").TriggerValue ?? false;
+        set => AuraTree.GetTriggerByPath<IHotkeyIsActiveTrigger>("./TargetAura 1").TriggerValue = value;
+    }
+
+    public bool Trigger2IsActive
+    {
+        get => AuraTree.GetTriggerByPath<IHotkeyIsActiveTrigger>("./TargetAura 2").TriggerValue ?? false;
+        set => AuraTree.GetTriggerByPath<IHotkeyIsActiveTrigger>("./TargetAura 2").TriggerValue = value;
+    }
+
+    public bool Trigger3IsActive
+    {
+        get => AuraTree.GetTriggerByPath<IHotkeyIsActiveTrigger>("./TargetAura 3").TriggerValue ?? false;
+        set => AuraTree.GetTriggerByPath<IHotkeyIsActiveTrigger>("./TargetAura 3").TriggerValue = value;
+    }
+
+    public bool Trigger4IsActive
+    {
+        get => AuraTree.GetTriggerByPath<IHotkeyIsActiveTrigger>("./TargetAura 4").TriggerValue ?? false;
+        set => AuraTree.GetTriggerByPath<IHotkeyIsActiveTrigger>("./TargetAura 4").TriggerValue = value;
+    }
+
+    protected override void OnInitialized()
+    {
+        ChangeTrackers.Add(Observable.Timer(DateTimeOffset.Now, TimeSpan.FromSeconds(1)));
+        base.OnInitialized();
+    }
+}
+```
+
+## UserOverlay.razor
+```html
+@using PoeShared.Blazor.Controls
+@inherits BlazorReactiveComponent
+
+<h3 class="text-center shadow-1">Custom Toggles</h3>
+
+<div class="text-center mt-4 mx-2 d-flex gap-1 flex-column alert alert-info">
+    @if (Trigger1IsActive){
+         <ToggleButton @bind-IsChecked="@Trigger1IsActive"
+            Class="btn btn-success">
+            Trigger <b>1</b> is active
+        </ToggleButton>
+    } else {
+         <ToggleButton @bind-IsChecked="@Trigger1IsActive"
+            Class="btn btn-outline-danger">
+            Trigger <b>1</b> is inactive
+        </ToggleButton>
+    }
+    <ToggleButton @bind-IsChecked="@Trigger2IsActive">
+        @if (Trigger2IsActive){
+            <i class="fa-solid fa-toggle-on"></i>
+            <strong>Trigger 2 is active</strong>
+        } else {
+            <i class="fa-solid fa-toggle-off"></i>
+            <span>Trigger 2 is not active</span>
+        }
+    </ToggleButton>
+    <span class="d-flex gap-1 align-self-center">
+
+        <ToggleButton @bind-IsChecked="@Trigger3IsActive">
+            Trigger <b>3</b>
+        </ToggleButton>
+        @if (Trigger3IsActive){
+            <span class="vr"></span>
+
+            <ToggleButton @bind-IsChecked="@Trigger4IsActive">
+                Trigger <b>4</b>
+            </ToggleButton>
+        }
+    </span>
+</div>
+```
+
+---
+
+# Breakdown
+## UserOverlay.cs
+Nothing special—just several properties accessing triggers.
+
+## UserOverlay.razor
+This file contains several customization approaches. In real projects try not to mix too many techniques—such code is harder to maintain!
+
+```html
+<div class="text-center mt-4 mx-2 d-flex gap-1 flex-column alert alert-info">
+```
+The class list changed:
+- `flex-column` – combined with `d-flex` it renders elements stacked vertically instead of in a row
+
+```html
+@if (Trigger1IsActive){
+         <ToggleButton @bind-IsChecked="@Trigger1IsActive"
+            Class="btn btn-success">
+            Trigger <b>1</b> is active
+        </ToggleButton>
+    } else {
+         <ToggleButton @bind-IsChecked="@Trigger1IsActive"
+            Class="btn btn-outline-danger">
+            Trigger <b>1</b> is inactive
+        </ToggleButton>
+    }
+```
+First variant: on each render we choose the button style beforehand and render a completely new component. We don't change properties of the same component—we create a new one. Use this when too many properties change; otherwise it's a bit "dirty".
+
+```html
+<ToggleButton @bind-IsChecked="@Trigger2IsActive">
+        @if (Trigger2IsActive){
+            <i class="fa-solid fa-toggle-on"></i>
+            <strong>Trigger 2 is active</strong>
+        } else {
+            <i class="fa-solid fa-toggle-off"></i>
+            <span>Trigger 2 is not active</span>
+        }
+</ToggleButton>
+```
+Second variant—the most common. Typically you'll update the *content* of a component rather than the component itself.
+
+```html
+ <span class="d-flex gap-1 align-self-center">
+        <ToggleButton @bind-IsChecked="@Trigger3IsActive">
+            Trigger <b>3</b>
+        </ToggleButton>
+        @if (Trigger3IsActive){
+            <span class="vr"></span>
+
+            <ToggleButton @bind-IsChecked="@Trigger4IsActive">
+                Trigger <b>4</b>
+            </ToggleButton>
+        }
+    </span>
+```
+Here we use conditions to render an additional button dynamically. It appears only when `Trigger 3` is active. You could build a whole hierarchy of settings like this. But remember that a "jumping" interface is bad UX—avoid it when possible.

--- a/scripting/blazor-windows/toggles-styling-css-load.md
+++ b/scripting/blazor-windows/toggles-styling-css-load.md
@@ -1,0 +1,99 @@
+---
+title: 10. Connecting a CSS file – LoadCss
+description:
+published: true
+date: 2025-08-17T09:21:21.000Z
+tags:
+editor: markdown
+dateCreated: 2025-05-11T16:22:32.324Z
+---
+
+# Alternative way to load CSS
+
+## LoadCss – loading from code
+EyeAuras provides a set of tools called `IJsPoeBlazorUtils`. Just like `IAuraTreeScriptingApi` you can inject it into your component and use its methods to load CSS at runtime.
+```csharp
+/// <summary>
+/// Loads CSS file dynamically
+/// </summary>
+Task LoadCss(string cssPath);
+```
+
+The key difference from using `HeadContent` or inline styles is that *you* control when the CSS file loads. It can be on page load, button click, theme switch—anything. Full control is in your hands.
+![Demo](https://s3.eyeauras.net/media/2025/05/OTFy9w6Fgm.png)
+
+## UserOverlay.cs
+```csharp
+public partial class UserOverlay : BlazorReactiveComponent {
+
+    [Inject]
+    public IAuraTreeScriptingApi AuraTree { get; init; }
+
+    [Inject]
+    public PoeShared.Blazor.Services.IJsPoeBlazorUtils PoeBlazorUtils { get; init; }
+
+    public bool TriggerIsActive
+    {
+        get => AuraTree.GetTriggerByPath<IHotkeyIsActiveTrigger>("./TargetAura").TriggerValue ?? false;
+        set => AuraTree.GetTriggerByPath<IHotkeyIsActiveTrigger>("./TargetAura").TriggerValue = value;
+    }
+
+    protected override void OnInitialized()
+    {
+        ChangeTrackers.Add(Observable.Timer(DateTimeOffset.Now, TimeSpan.FromSeconds(1)));
+        base.OnInitialized();
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        await base.OnInitializedAsync();
+
+        await PoeBlazorUtils.LoadCss("Styles.css");
+    }
+}
+```
+
+## UserOverlay.razor
+```html
+@using PoeShared.Blazor.Controls
+@inherits BlazorReactiveComponent
+
+<h3 class="text-center shadow-1">CSS via HeadContent</h3>
+
+<div class="text-center mt-4">
+    <ToggleButton
+        @bind-IsChecked="@TriggerIsActive"
+        Class="btn custom-button">
+                Trigger is Active
+    </ToggleButton>
+</div>
+```
+
+## Styles.css
+```css
+.custom-button {
+    background: lime;
+    color: black;
+    width: 80%;
+}
+```
+
+---
+
+# Breakdown
+## UserOverlay.cs
+```csharp
+[Inject]
+public PoeShared.Blazor.Services.IJsPoeBlazorUtils PoeBlazorUtils { get; init; }
+```
+As with `IAuraTreeScriptingApi` we inject another service to load CSS.
+
+```csharp
+    protected override async Task OnInitializedAsync()
+    {
+        await base.OnInitializedAsync();
+
+        await PoeBlazorUtils.LoadCss("Styles.css");
+    }
+```
+Here I load CSS right after the component is initialized—services are prepared but rendering hasn't happened yet. More on this lifecycle in [Microsoft's article](https://learn.microsoft.com/en-us/aspnet/core/blazor/components/lifecycle?view=aspnetcore-9.0).

--- a/scripting/blazor-windows/toggles-styling-cssfile.md
+++ b/scripting/blazor-windows/toggles-styling-cssfile.md
@@ -1,0 +1,133 @@
+---
+title: 9. Connecting a CSS file – HeadContent
+description:
+published: true
+date: 2025-08-17T09:21:21.000Z
+tags:
+editor: markdown
+dateCreated: 2025-05-11T16:12:56.395Z
+---
+
+# CSS files
+CSS is usually distributed as separate files containing class definitions; sometimes there are thousands of them!
+
+## The HTML `head` tag
+If you click on a C# overlay and press `F12` (open dev tools), at the top of the HTML you'll see something like:
+```html
+<head>
+    <meta charset="utf-8">
+    <base href="/">
+
+    <link href="_content/AntDesign/css/ant-design-blazor.css" rel="stylesheet">
+    <link href="_content/PoeShared.Blazor.Wpf/css/bootstrap.css" rel="stylesheet">
+    <link href="_content/PoeShared.Blazor.Wpf/css/bootstrap-extra.css" rel="stylesheet">
+    <link href="_content/PoeShared.Blazor.Wpf/css/app.css" rel="stylesheet">
+    <link href="_content/PoeShared.Blazor.Wpf/css/font-awesome6.min.css" rel="stylesheet">
+    <link href="_content/PoeShared.Blazor.Wpf/css/font-play-regular.css" rel="stylesheet">
+    <link href="_content/PoeShared.Blazor.Controls/assets/css/main-colors.css" rel="stylesheet">
+    <link href="_content/PoeShared.Blazor.Controls/assets/css/main-style.css" rel="stylesheet">
+    <link href="_content/PoeShared.Blazor.Controls/assets/css/main-ant-blazor.css" rel="stylesheet">
+    <link href="_content/EyeAuras.Blazor.Shared/EyeAuras.Blazor.Shared.bundle.scp.css" rel="stylesheet">
+    <link href="EyeAuras.styles.css" rel="stylesheet">
+</head>
+```
+This is where additional styles and sometimes scripts are declared. The browser processes them right at startup so it knows what to load. During rendering it uses the styles to control layout. Our style file has to end up here somehow. But first, let's simply create it.
+
+## Creating a CSS file
+In the overlay script click `New` -> `CSS` and enter a name. We'll use the default name `Styles`. You can choose any name, just remember to update the path in code accordingly.
+
+![New CSS](https://s3.eyeauras.net/media/2025/05/NVIDIA_Overlay_mzNnQuvluB.png)
+
+## Default CSS
+By default EyeAuras creates a file like:
+```css
+body, html {
+    background: yellow;
+}
+```
+This would color the window/overlay background yellow. But merely creating a CSS file doesn't apply it—you must also connect it so the browser knows where to find it.
+
+## HeadContent – declarative approach
+In Blazor the header content is controlled via [HeadContent](https://learn.microsoft.com/en-us/aspnet/core/blazor/components/control-head-content?view=aspnetcore-9.0). It allows you to append extra CSS files to the HTML header when needed.
+
+Your component loads, finds `HeadContent` and it appends links to the `head` element—after that the browser handles everything. For example:
+
+```csharp
+<HeadContent>
+    <link href="Styles.css" rel="stylesheet"/>
+</HeadContent>
+```
+This code connects `Styles.css` to the header. I spared your eyes and inserted the code for a green button instead of the default CSS without changing the background.
+
+![Demo](https://s3.eyeauras.net/media/2025/05/OTFy9w6Fgm.png)
+
+## UserOverlay.cs
+```csharp
+public partial class UserOverlay : BlazorReactiveComponent {
+
+    [Inject]
+    public IAuraTreeScriptingApi AuraTree { get; init; }
+
+    public bool TriggerIsActive
+    {
+        get => AuraTree.GetTriggerByPath<IHotkeyIsActiveTrigger>("./TargetAura").TriggerValue ?? false;
+        set => AuraTree.GetTriggerByPath<IHotkeyIsActiveTrigger>("./TargetAura").TriggerValue = value;
+    }
+
+    protected override void OnInitialized()
+    {
+        ChangeTrackers.Add(Observable.Timer(DateTimeOffset.Now, TimeSpan.FromSeconds(1)));
+        base.OnInitialized();
+    }
+}
+```
+
+## UserOverlay.razor
+```html
+@using PoeShared.Blazor.Controls
+@inherits BlazorReactiveComponent
+
+<HeadContent>
+    <link href="Styles.css" rel="stylesheet"/>
+</HeadContent>
+
+<h3 class="text-center shadow-1">CSS via HeadContent</h3>
+
+<div class="text-center mt-4">
+    <ToggleButton
+        @bind-IsChecked="@TriggerIsActive"
+        Class="btn custom-button">
+                Trigger is Active
+    </ToggleButton>
+</div>
+```
+
+## Styles.css
+```css
+.custom-button {
+    background: lime;
+    color: black;
+    width: 80%;
+}
+```
+
+---
+
+# Breakdown
+## UserOverlay.razor
+```html
+<HeadContent>
+    <link href="Styles.css" rel="stylesheet"/>
+</HeadContent>
+```
+The key part that connects the styles.
+
+## Styles.css
+```css
+.custom-button {
+    background: lime;
+    color: black;
+    width: 80%;
+}
+```
+Our style storage. There's only one class now, but you can create as many as you like. User styles are connected last, giving you full control to completely change the interface if needed.

--- a/scripting/blazor-windows/toggles-styling-inline.md
+++ b/scripting/blazor-windows/toggles-styling-inline.md
@@ -1,0 +1,129 @@
+---
+title: 8. Adding CSS – Inline
+description:
+published: true
+date: 2025-08-17T09:21:21.000Z
+tags:
+editor: markdown
+dateCreated: 2025-05-11T15:48:02.521Z
+---
+
+# CSS and what it is
+CSS (Cascading Style Sheets) describes the **styles** of your interface: colors, sizes, and so on.
+
+The mechanism is extremely powerful and over the years has gained so many details that a full description would fill a thick book. Fortunately it's also simple—*easy to learn, hard to master*—and you don't need to understand its internals to use it effectively.
+
+## [Bootstrap](https://getbootstrap.com/docs/5.3/getting-started/introduction/)
+Bootstrap is a massive collection of useful CSS classes covering most common requests—colored buttons, editors, etc. EyeAuras loads Bootstrap CSS/JS automatically, so all classes from the documentation are available in any overlay by default. We've already been using them throughout the series.
+
+Sometimes standard styles aren't enough and you want something custom. Let's take the code that toggles a trigger and simply recolor the button using CSS.
+
+![Demo](https://s3.eyeauras.net/media/2025/05/3UAeooHWHD.png)
+
+## UserOverlay.cs
+```csharp
+public partial class UserOverlay : BlazorReactiveComponent {
+
+    [Inject]
+    public IAuraTreeScriptingApi AuraTree { get; init; }
+
+    public bool TriggerIsActive
+    {
+        get => AuraTree.GetTriggerByPath<IHotkeyIsActiveTrigger>("./TargetAura").TriggerValue ?? false;
+        set => AuraTree.GetTriggerByPath<IHotkeyIsActiveTrigger>("./TargetAura").TriggerValue = value;
+    }
+
+    protected override void OnInitialized()
+    {
+        ChangeTrackers.Add(Observable.Timer(DateTimeOffset.Now, TimeSpan.FromSeconds(1)));
+        base.OnInitialized();
+    }
+}
+```
+
+## UserOverlay.razor
+```html
+@using PoeShared.Blazor.Controls
+@inherits BlazorReactiveComponent
+
+<style>
+.custom-button {
+    background: lime;
+    color: black;
+    width: 80%;
+}
+</style>
+
+<h3 class="text-center shadow-1">Toggle Trigger</h3>
+
+<div class="text-center mt-4">
+    <ToggleButton
+        @bind-IsChecked="@TriggerIsActive"
+        Class="btn custom-button">
+                Trigger is Active
+    </ToggleButton>
+</div>
+
+<p class="text-center mt-3 alert alert-info" style="font-size: 1.5rem;">
+    @if (TriggerIsActive){
+        <span class="shadow-1">Trigger is currently active</span>
+    } else {
+        <span class="text-warning shadow-1">Trigger is currently not active</span>
+    }
+</p>
+```
+
+![Demo](https://s3.eyeauras.net/media/2025/05/NVIDIA_Overlay_WPu1ZGwKwS.gif)
+
+---
+
+# Breakdown
+## UserOverlay.razor
+```html
+<style>
+.custom-button {
+    background: lime;
+    color: black;
+    width: 80%;
+}
+</style>
+```
+This is an inline style—define a CSS class directly in the component and use it right away. It's simple and fine for small projects, but has downsides. It's better to switch to proper CSS files as your project grows; that's the standard approach in web development.
+
+# Additional
+ChatGPT and other bots handle CSS well and can generate all kinds of classes. For example, here's CSS from ChatGPT 4o that adds a gradient. We're not discussing optimality—leave that to the pros :)
+```css
+.custom-button {
+    background: linear-gradient(90deg, red, darkred);
+    color: white;
+    border: none;
+    padding: 0.6rem 1.2rem;
+    font-size: 1rem;
+    border-radius: 0.3rem;
+    cursor: pointer;
+    position: relative;
+    overflow: hidden;
+    transition: background 0.3s ease;
+}
+
+.custom-button::before {
+    content: '';
+    position: absolute;
+    top: 0; left: -100%;
+    width: 200%;
+    height: 100%;
+    background: linear-gradient(90deg, rgba(255,255,255,0.1), rgba(255,255,255,0.4), rgba(255,255,255,0.1));
+    transition: left 0.6s ease-in-out;
+    z-index: 1;
+}
+
+.custom-button:hover::before {
+    left: 100%;
+}
+
+.custom-button > * {
+    position: relative;
+    z-index: 2;
+}
+```
+![Demo 1](https://s3.eyeauras.net/media/2025/05/J0g2tAOpQa.gif)


### PR DESCRIPTION
## Summary
- Translate and add introductory Blazor Windows documentation in English
- Document overlay setup, CSS styling, and JavaScript loading features
- Establish English `scripting/blazor-windows` docs folder

## Testing
- `pytest`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a19e90b6008325a84511334dc6ecab