### PR TITLE
Add Break and Return node translations

### DIFF
--- a/behavior-trees/nodes/Break.md
+++ b/behavior-trees/nodes/Break.md
@@ -1,0 +1,40 @@
+---
+title: Break
+description:
+published: true
+date: 2025-08-17T09:40:43.000Z
+tags:
+editor: markdown
+dateCreated: 2025-08-17T09:40:43.000Z
+---
+
+# Break
+**Break** is a node used inside macros to immediately exit a Repeat loop, similar to the `break` statement in C#. It lets you stop the current loop without waiting for all iterations to finish.
+
+## When to use
+- When a Repeat loop should stop under a certain condition.
+- When further iterations make no sense (the goal is reached or the situation changed).
+
+## How it works
+- Place the Break node inside the body of a Repeat loop or a Block node.
+- As soon as Break triggers (for example, the condition is met), the macro exits the current Block or Repeat.
+- The macro then continues with the actions after the loop.
+
+## Example with Repeat
+```
+Repeat (up to 5 times)
+├── SomeAction
+├── IfThenElse
+│   ├── Condition: Enemy found
+│   ├── If yes: Break
+│   └── If no: (nothing)
+└── Another action
+```
+In this example, if an enemy is found during one of the iterations, Break is executed—the Repeat loop immediately stops and the macro continues with the node following Repeat. The remaining iterations will not run.
+
+---
+
+## Good to know
+- The main use case is inside Repeat; its purpose is to exit the loop as soon as needed.
+- Alternatively, you can use this node inside Block nodes to better structure your code.
+

--- a/behavior-trees/nodes/return.md
+++ b/behavior-trees/nodes/return.md
@@ -1,0 +1,32 @@
+---
+title: Return
+description:
+published: true
+date: 2025-08-17T09:40:43.000Z
+tags:
+editor: markdown
+dateCreated: 2025-08-17T09:40:43.000Z
+---
+
+# Return
+**Return** is a node that allows you to immediately finish executing a macro with a specific status—similar to the `return` statement in C#. It is available only in macros.
+
+## When to use
+Sometimes a macro should end without waiting for every step to run—for example, if something went wrong or the required condition is already met. Return is used for this:
+- Stop the macro on failure or an error.
+- Interrupt execution under a certain condition.
+
+## How it works
+- Insert this node at the desired point in the macro.
+- Specify the status the macro should finish with: `Success` or `Failure`.
+- Once Return fires, the macro terminates immediately; anything after it will **not run**.
+
+## Example
+```csharp
+IfThenElse
+├── Condition: No mana
+├── If yes: Return (Result = Failure)
+└── If no: Continue with other actions
+```
+In this example, if there is no mana, the macro ends with a `Failure` status and all subsequent steps are skipped.
+


### PR DESCRIPTION
## Summary
- add English translation for Break node that allows early exit from Repeat loops
- add English translation for Return node to finish macro execution with a specified status

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a2fbbb808325b7504dffed5e38d1