### PR TITLE
docs(translation): sync 1 wiki document(s)

### DIFF
--- a/changelogs/9423.md
+++ b/changelogs/9423.md
@@ -1,0 +1,30 @@
+---
+title: 1.9.9423
+description: April bugfix follow-up
+published: true
+date: 2026-04-07T00:10:00.000Z
+tags: ai, ui, bugfix, ai-translated
+editor: markdown
+dateCreated: 2026-04-07T00:10:00.000Z
+---
+# AI patch - 1.9.9423 [RU](/ru/changelogs/9423)/[EN](/en/changelogs/9423)
+
+This update is mostly focused on bug fixes and polishing a few parts of the UI.
+
+## AI - Code Blocks
+
+Added code rendering in dedicated blocks.
+
+![EA Code Block](https://s3.eyeauras.net/media/2026/04/EyeAuras_A7ldmDXhOL.png)
+
+## AI - EyeAuras Gateway
+
+Added budget and limit display. Just hover over the status next to your profile.
+
+![EA Gateway Limits](https://s3.eyeauras.net/media/2026/04/EyeAuras_8KaFATD3g5.png)
+
+## Bugfixes and improvements
+
+* **[UI]** Fixed an issue where the error list did not appear after clicking the icon
+* **[UI]** Fixed panel resizing issues where the mouse could get "stuck" while dragging
+* **[Export]** Fixed an issue with aura pre-compilation during `Export` when `Binaries Only` mode is enabled


### PR DESCRIPTION
## Run Summary

| Field | Value |
| --- | --- |
| Translator app | WikiJsTranslator.Bot |
| Translator version | 1.9.9412.0 |
| OS | Ubuntu 20.04.6 LTS |
| Branch | `auto/translate/published-en-ru` |
| Base branch | `main` |
| Model | `gpt-5.4` |
| Reasoning | `Medium` |
| Analyzed | 912 |
| Eligible | 767 |
| Untranslated before batch | 1 |
| Untranslated after batch | 0 |
| Attempted | 1 |
| Translated | 1 |
| No-op | 0 |
| Elapsed | 00:00:16.3668132 |

## Changed Files

| Decision | Source | Target | Source date | Previous target date | Elapsed |
| --- | --- | --- | --- | --- | --- |
| `CreateMissingEnglish` | [`ru/changelogs/9423.md`](https://github.com/iXab3r/EyeAuras.Wiki/blob/main/ru/changelogs/9423.md) | [`changelogs/9423.md`](https://github.com/iXab3r/EyeAuras.Wiki/blob/auto%2Ftranslate%2Fpublished-en-ru/changelogs/9423.md) | 2026-04-07T00:10:00.0000000+00:00 | <missing> | 00:00:16.0361546 |