### PR TITLE
docs(translation): sync 1 wiki document(s)

### DIFF
--- a/changelogs/9435.md
+++ b/changelogs/9435.md
@@ -1,23 +1,23 @@
 ---
 title: 1.9.9435
-description: April - follow-up patch
+description: April follow-up patch
 published: true
-date: 2026-04-11T00:10:00.000Z
+date: 2026-04-11T16:55:18.045Z
 tags: ai, export, bugfix, ai-translated
 editor: markdown
 dateCreated: 2026-04-11T00:10:00.000Z
 ---
 # 1.9.9435 [RU](/ru/changelogs/9435)/[EN](/en/changelogs/9435)
 
-## AI - Codex
+## AI Codex
 
-`Codex` inside EyeAuras continues to get a more practical UX: separate `threads`, a clearer workflow, and overall a better mode for complex coding tasks.
+`Codex` inside EyeAuras keeps getting a more practical UX: separate `threads`, a clearer workflow, and in general a more usable mode for complex coding tasks.
 
-If the regular `AI Assistant` works best as a quick in-app chat and reference tool, `Codex` is already better thought of as a separate mode for heavier technical work.
+If the regular `AI Assistant` works better as a quick in-app chat and reference tool, `Codex` is already better thought of as a separate mode for heavier technical work.
 
 [Read more about AI Codex Coding Assistant](/features/ai-codex-coding-assistant)
 
-![Codex](https://s3.eyeauras.net/media/2026/04/EyeAuras_TyMJnKr1Rb.png =x600)
+![Codex](https://s3.eyeauras.net/media/2026/04/EyeAuras_TyMJnKr1Rb.png =x200)
 
 ## Export / Import
 
@@ -25,10 +25,10 @@ The `Export / Import` flow is also continuing to improve. It is now a much clear
 
 [Read more about Export / Import](/features/export-import)
 
-![Export / Import](https://s3.eyeauras.net/media/2026/04/EyeAuras_1QpMi38ffV.png =x600)
+![Export / Import](https://s3.eyeauras.net/media/2026/04/EyeAuras_1QpMi38ffV.png =x400)
 
 ## Fixes and improvements
 
 * **[AI]** Improved `EyeAuras Gateway` budget monitoring
-* **[UI]** Improved display and formatting for code blocks
+* **[UI]** Improved code block rendering and formatting
 * **[UI]** Fixed a bug where authors can once again download their own packages regardless of the selected download policy


### PR DESCRIPTION
## Run Summary

| Field | Value |
| --- | --- |
| Translator app | WikiJsTranslator.Bot |
| Translator version | 1.9.9424.0 |
| OS | Ubuntu 20.04.6 LTS |
| Branch | `auto/translate/published-en-ru` |
| Base branch | `main` |
| Model | `gpt-5.4` |
| Reasoning | `Medium` |
| Analyzed | 917 |
| Eligible | 772 |
| Untranslated before batch | 377 |
| Untranslated after batch | 377 |
| Attempted | 377 |
| Translated | 1 |
| No-op | 376 |
| Elapsed | 00:00:14.3937279 |

## Changed Files

| Decision | Source | Target | Source date | Previous target date | Elapsed |
| --- | --- | --- | --- | --- | --- |
| `SyncEnglishFromRussian` | [`ru/changelogs/9435.md`](https://github.com/iXab3r/EyeAuras.Wiki/blob/main/ru/changelogs/9435.md) | [`changelogs/9435.md`](https://github.com/iXab3r/EyeAuras.Wiki/blob/auto%2Ftranslate%2Fpublished-en-ru/changelogs/9435.md) | 2026-04-11T16:55:18.0450000+00:00 | 2026-04-11T00:10:00.0000000+00:00 | 00:00:13.6057836 |