### PR TITLE
docs(translation): sync 1 wiki document(s)

### DIFF
--- a/changelogs/9467.md
+++ b/changelogs/9467.md
@@ -1,0 +1,28 @@
+---
+title: 1.9.9467
+description: Draft April changelog
+published: true
+date: 2026-04-14T00:10:00.000Z
+tags: scripting, nuget, bugfix, ai-translated
+editor: markdown
+dateCreated: 2026-04-14T00:10:00.000Z
+---
+# 1.9.9467 [RU](/ru/changelogs/9467)/[EN](/en/changelogs/9467)
+
+## C# Scripting - Script Properties / NuGet
+
+`C#` scripts now have a `Properties` button that opens a separate script properties window. It brings the main settings and dependencies together in one place: `Overview`, `NuGet` package management, `References` for internal and external assemblies, and `Embedded Resources` for files that should be distributed together with the script.
+
+![Script Properties NuGet](https://s3.eyeauras.net/media/2026/04/EyeAuras_9TwUfSgAH2.png =x600)
+
+Learn more:
+
+* [Connecting external assemblies](/scripting/nuget)
+* [Embedded resources](/scripting/embedded-resources)
+
+## Fixes and improvements
+
+* **[AI]** `Codex` now understands EyeAuras-specific details better, so it should be more useful for complex technical tasks
+* **[UI]** Improved the `Export` and `Import` dialogs to make them more convenient to use
+* **[UI]** Fixed jerky dragging for `Blazor` windows, where the window could suddenly jump to the side
+* **[UI]** Fixed the `ICodeHighlightService` error


### PR DESCRIPTION
## Run Summary

| Field | Value |
| --- | --- |
| Translator app | WikiJsTranslator.Bot |
| Translator version | 1.9.9424.0 |
| OS | Ubuntu 20.04.6 LTS |
| Branch | `auto/translate/published-en-ru` |
| Base branch | `main` |
| Model | `gpt-5.4` |
| Reasoning | `Medium` |
| Analyzed | 918 |
| Eligible | 773 |
| Untranslated before batch | 378 |
| Untranslated after batch | 378 |
| Attempted | 378 |
| Translated | 1 |
| No-op | 377 |
| Elapsed | 00:00:18.1931712 |

## Changed Files

| Decision | Source | Target | Source date | Previous target date | Elapsed |
| --- | --- | --- | --- | --- | --- |
| `CreateMissingEnglish` | [`ru/changelogs/9467.md`](https://github.com/iXab3r/EyeAuras.Wiki/blob/main/ru/changelogs/9467.md) | [`changelogs/9467.md`](https://github.com/iXab3r/EyeAuras.Wiki/blob/auto%2Ftranslate%2Fpublished-en-ru/changelogs/9467.md) | 2026-04-14T00:10:00.0000000+00:00 | <missing> | 00:00:16.8299387 |