### PR TITLE
docs(translation): sync 1 wiki document(s)

### DIFF
--- a/changelogs/9564.md
+++ b/changelogs/9564.md
@@ -1,0 +1,40 @@
+---
+title: 1.9.9564
+description: Minor patch - EyePad, preview, and SDK
+published: true
+date: 2026-05-04T00:22:42.311Z
+tags: eyepad, ui, preview, sdk, ai-translated
+editor: markdown
+dateCreated: 2026-05-04T00:22:42.311Z
+---
+# 1.9.9564 [RU](/ru/changelogs/9564)/[EN](/en/changelogs/9564)
+
+A small follow-up patch after the larger [1.9.9545](/ru/changelogs/9545) update. This release mainly includes fixes for [EyePad](/ru/features/eyepad), video preview, and SDK dependencies.
+
+## EyePad
+
+Fixed file launching through EyePad.
+
+If EyeAuras is started with a `.json` or `.v1.enc` file, that file is now treated as an aura file and launched through the aura tab. Regularly opening a `.json` file inside EyePad still works as opening it as a text file.
+
+A few related fixes were also included:
+
+* if the passed file cannot be launched, the application now exits with `InvalidData`
+* if startup fails with an error, EyeAuras should no longer additionally exit afterward as if everything succeeded
+* added E2E tests for these scenarios
+
+## Video preview
+
+Fixed a race condition in video preview: the old frame buffer could already be freed while the UI was still trying to read a frame from it.
+
+Now those stale frames are simply skipped or logged instead of crashing the preview.
+
+## Fixes and improvements
+
+* **[EyePad]** `.json` and `.v1.enc` files passed on application startup now open as aura files.
+* **[EyePad]** Regular `.json` opening inside EyePad remains text-based.
+* **[EyePad]** If a file cannot be launched in one-shot mode, the application now exits with `InvalidData`.
+* **[EyePad]** A startup error for the input file should no longer cause the application to terminate twice.
+* **[Image Preview]** Fixed a race condition when freeing the old video frame buffer.
+* **[Notifications]** Fixed `EA-1258`: the notification overlay could break after obfuscation.
+* **[SDK]** Updated `ImageSharp` and `Unity`, and removed the old direct reference to `OpenAI 1.7.2` to eliminate `NU1605` downgrade conflicts.


### PR DESCRIPTION
## Run Summary

| Field | Value |
| --- | --- |
| Translator app | WikiJsTranslator.Bot |
| Translator version | 1.9.9424.0 |
| OS | Ubuntu 20.04.6 LTS |
| Branch | `auto/translate/published-en-ru` |
| Base branch | `main` |
| Model | `gpt-5.4` |
| Reasoning | `Medium` |
| Analyzed | 1073 |
| Eligible | 927 |
| Untranslated before batch | 454 |
| Untranslated after batch | 454 |
| Attempted | 454 |
| Translated | 1 |
| No-op | 453 |
| Elapsed | 00:00:16.7491990 |

## Changed Files

| Decision | Source | Target | Source date | Previous target date | Elapsed |
| --- | --- | --- | --- | --- | --- |
| `CreateMissingEnglish` | [`ru/changelogs/9564.md`](https://github.com/iXab3r/EyeAuras.Wiki/blob/main/ru/changelogs/9564.md) | [`changelogs/9564.md`](https://github.com/iXab3r/EyeAuras.Wiki/blob/auto%2Ftranslate%2Fpublished-en-ru/changelogs/9564.md) | 2026-05-04T00:22:42.3110000+00:00 | <missing> | 00:00:16.1057391 |